### PR TITLE
Add toradex apalis imx6 board configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,21 @@ script: |
     cachix push cross-armed $(nix-store -qd result)
   fi
 
+  # build a toradex apalis imx6 sample image
+  nix-build . \
+    --cores 2 \
+    --max-jobs 2 \
+    --no-build-output \
+    -I nixpkgs=nixpkgs \
+    -I machine=machines/toradex_apalis_imx6 \
+    -I image=images/minimal
+
+  # push toradex apalis imx6 with permission
+  if [[ ${CACHIX_AUTH_TOKEN:-} ]]; then
+    cachix push cross-armed $(readlink -f result)
+    cachix push cross-armed $(nix-store -qd result)
+  fi
+
   # kill the background process
   kill %1
   )

--- a/machines/toradex_apalis_imx6/default.nix
+++ b/machines/toradex_apalis_imx6/default.nix
@@ -1,0 +1,62 @@
+{ config, pkgs, ... }:
+let
+  toradex_apalis_imx6 = import ./system.nix;
+in
+{
+  # specify the system we're compiling to
+  nixpkgs.crossSystem = toradex_apalis_imx6;
+
+  # enable free firmware
+  hardware.enableRedistributableFirmware = true;
+
+  # specify a good kernel version
+  boot.kernelPackages = pkgs.linuxPackages_5_0;
+
+  # do our own boot-loader
+  boot.loader.grub.enable = false;
+  boot.loader.systemd-boot.enable = false;
+  boot.loader.generic-extlinux-compatible.enable = false;
+
+  # build & install boot loader
+  sdImage.populateBootCommands = let
+    kernel = toradex_apalis_imx6.platform.kernelTarget;
+    init = "${config.system.build.toplevel}/init";
+    root = "/dev/mmcblk2p2";
+    uboot = pkgs.buildUBoot {
+      defconfig = "apalis_imx6_defconfig";
+      extraMeta.platforms = [toradex_apalis_imx6.system];
+      filesToInstall = ["SPL" "u-boot.img"];
+    };
+    uEnv = pkgs.writeText "uEnv.txt" ''
+      bootdir=
+      bootcmd=run uenvcmd;
+      bootfile=${kernel}
+      fdtfile=${toradex_apalis_imx6.dtb}
+      loadaddr=0x11000000
+      fdtaddr=0x12000000
+      loadfdt=load mmc 0:1 ''${fdtaddr} ''${fdtfile}
+      loaduimage=load mmc 0:1 ''${loadaddr} ''${bootfile}
+      uenvcmd=mmc rescan; run loaduimage; run loadfdt; run fdtboot
+      fdtboot=run mmc_args; bootz ''${loadaddr} - ''${fdtaddr}
+      mmc_args=setenv bootargs console=''${console} ''${optargs} root=${root} rootfstype=ext4 init=${init}
+    '';
+
+    # Populate result/nix-support/tezi folder for ToradexEasyInstaller.
+    populateToradexTezi = ''
+    mkdir -p $out/nix-support/tezi/
+    cp ${uboot}/SPL $out/nix-support/tezi/
+    cp ${uboot}/u-boot.img $out/nix-support/tezi/
+    cp ${config.boot.kernelPackages.kernel}/${kernel} $out/nix-support/tezi/
+    cp ${config.boot.kernelPackages.kernel}/dtbs/${toradex_apalis_imx6.dtb} $out/nix-support/tezi/
+    cp ${uEnv} $out/nix-support/tezi/uEnv.txt
+    '';
+
+  in ''
+    ${populateToradexTezi}
+    cp ${uboot}/SPL boot/
+    cp ${uboot}/u-boot.img boot/
+    cp ${config.boot.kernelPackages.kernel}/${kernel} boot/
+    cp ${config.boot.kernelPackages.kernel}/dtbs/${toradex_apalis_imx6.dtb} boot/
+    cp ${uEnv} boot/uEnv.txt
+  '';
+}

--- a/machines/toradex_apalis_imx6/default.nix
+++ b/machines/toradex_apalis_imx6/default.nix
@@ -7,7 +7,7 @@ in
   nixpkgs.crossSystem = toradex_apalis_imx6;
 
   # enable free firmware
-  hardware.enableRedistributableFirmware = true;
+  hardware.enableRedistributableFirmware = false;
 
   # specify a good kernel version
   boot.kernelPackages = pkgs.linuxPackages_5_0;

--- a/machines/toradex_apalis_imx6/system.nix
+++ b/machines/toradex_apalis_imx6/system.nix
@@ -1,0 +1,22 @@
+with builtins;
+{
+  config = "armv7l-unknown-linux-gnueabihf";
+  system = "armv7l-linux";
+  platform = {
+    name = "toradex_apalis_imx6";
+    kernelBaseConfig = "imx_v6_v7_defconfig";
+    kernelAutoModules = false;
+    kernelTarget = "zImage";
+    kernelMajor = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.
+    kernelArch = "arm";
+    kernelDTB = true;
+    kernelPreferBuiltin = true;
+    kernelExtraConfig = ''
+    '';
+    gcc = {
+      cpu = "cortex-a9";
+      fpu = "neon";
+    };
+  };
+  dtb = "imx6q-apalis-eval.dtb";
+}


### PR DESCRIPTION
Greetings, this config's is working on my custom board. I was able to successfully build minimal image and boot into a root shell. 

One thing I wonder though - minimal image is 2.2gb size, but there is no multimedia, heavy frameworks or x server, similar yocto images is only 100-200 mb size.  Also, there are some x86 libraries that taking up some space:

```bash
[root@nixos-on-arm:~]# file /nix/store/k4mdai2d2qa5fdq2fflzan9ic6m43dz9-gcc-7.4.0/bin/gcc
/nix/store/k4mdai2d2qa5fdq2fflzan9ic6m43dz9-gcc-7.4.0/bin/gcc: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /nix/store/64wbvpm20in97sxgx6pfy6xy5d56fa8m-glibc-2.27/lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, stripped

[root@nixos-on-arm:~]# du -sh /nix/store/k4mdai2d2qa5fdq2fflzan9ic6m43dz9-gcc-7.4
130M	/nix/store/k4mdai2d2qa5fdq2fflzan9ic6m43dz9-gcc-7.4.0/
```